### PR TITLE
TASK: Provide better link to documentation

### DIFF
--- a/Classes/Step/FinalStep.php
+++ b/Classes/Step/FinalStep.php
@@ -52,7 +52,7 @@ class FinalStep extends AbstractStep
         /** @var AbstractFormElement $docs */
         $docs = $congratulations->createElement('docsLink', 'Neos.Setup:LinkElement');
         $docs->setLabel('Read the documentation');
-        $docs->setProperty('href', 'https://neos.readthedocs.org/');
+        $docs->setProperty('href', 'https://docs.neos.io');
         $docs->setProperty('target', '_blank');
 
         $contextEnv = Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: 'Development';


### PR DESCRIPTION
While this change may seem subtle, I think it can have a huge impact for the first contact with the system. Since most beginners will run the setup and the link to the documentation is currently to the reference documentation which is not a beginner's guide.