### PR TITLE
FEATURE: Detect mismatches between defaultDimensionSpacePoint and configured dimensions in ContentRepository settings

### DIFF
--- a/Classes/Infrastructure/Healthcheck/SiteDimensionHealthcheck.php
+++ b/Classes/Infrastructure/Healthcheck/SiteDimensionHealthcheck.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Neos\Neos\Setup\Infrastructure\Healthcheck;
+
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryIds;
+use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
+use Neos\Neos\Domain\Model\Site;
+use Neos\Neos\Domain\Repository\SiteRepository;
+use Neos\Neos\Domain\Repository\UserRepository;
+use Neos\Neos\Domain\Service\SiteService;
+use Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory;
+use Neos\Setup\Domain\Health;
+use Neos\Setup\Domain\HealthcheckEnvironment;
+use Neos\Setup\Domain\HealthcheckInterface;
+use Neos\Setup\Domain\Status;
+
+class SiteDimensionHealthcheck implements HealthcheckInterface
+{
+    public function __construct(
+        private SiteRepository            $siteRepository,
+        private ContentRepositoryRegistry $contentRepositoryRegistry,
+    )
+    {
+    }
+
+    public function getTitle(): string
+    {
+        return 'Neos Site/Dimension Configuration';
+    }
+
+    public function execute(HealthcheckEnvironment $environment): Health
+    {
+        $sites = $this->siteRepository->findAll();
+        if (count($sites->toArray()) === 0) {
+            return new Health(
+                'No site was added to the system.',
+                Status::NOT_RUN(),
+            );
+        }
+
+        $registeredContentRepositoryIds = $this->contentRepositoryRegistry->getContentRepositoryIds();
+        foreach ($sites as $site) {
+            assert($site instanceof Site);
+            $siteConfiguration = $site->getConfiguration();
+            if (!self::containsId($siteConfiguration->contentRepositoryId, $registeredContentRepositoryIds)) {
+                return new Health(
+                    'For Site ' . $site->getNodeName() . ', the configured Content Repository ' . $siteConfiguration->contentRepositoryId->value . ' is not registered. Please adjust the contentRepositoryId in Settings.yaml at Neos.Neos.sites / Neos.Neos.sitePresets, and then clear caches via ./flow flow:cache:flush --force.',
+                    Status::ERROR(),
+                );
+            }
+
+            $contentRepository = $this->contentRepositoryRegistry->get($siteConfiguration->contentRepositoryId);
+
+            if (!$contentRepository->getVariationGraph()->getDimensionSpacePoints()->contains($siteConfiguration->defaultDimensionSpacePoint)) {
+                return new Health(
+                    'For Site ' . $site->getNodeName() . ', the defaultDimensionSpacePoint ' . $siteConfiguration->defaultDimensionSpacePoint->toJson() . ' is not part of the configured dimensions of ContentRepository ' . $contentRepository->id->value . ' ' . $contentRepository->getVariationGraph()->getDimensionSpacePoints()->toJson() . '. You need to change Settings.yaml at Neos.Neos.sites.*.contentDimensions.defaultDimensionSpacePoint, and then clear the cache via ./flow flow:cache:flush --force.',
+                    Status::ERROR(),
+                );
+            }
+        }
+
+        return new Health(
+            'Site and Content Repository Dimensions match - all good!',
+            Status::OK(),
+        );
+    }
+
+
+    private static function containsId(ContentRepositoryId $needle, ContentRepositoryIds $ids)
+    {
+        foreach ($ids as $id) {
+            if ($id->equals($needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Classes/Infrastructure/Healthcheck/SiteDimensionHealthcheck.php
+++ b/Classes/Infrastructure/Healthcheck/SiteDimensionHealthcheck.php
@@ -7,9 +7,6 @@ use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryI
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Neos\Domain\Model\Site;
 use Neos\Neos\Domain\Repository\SiteRepository;
-use Neos\Neos\Domain\Repository\UserRepository;
-use Neos\Neos\Domain\Service\SiteService;
-use Neos\Neos\FrontendRouting\DimensionResolution\Resolver\UriPathResolverFactory;
 use Neos\Setup\Domain\Health;
 use Neos\Setup\Domain\HealthcheckEnvironment;
 use Neos\Setup\Domain\HealthcheckInterface;
@@ -26,7 +23,7 @@ class SiteDimensionHealthcheck implements HealthcheckInterface
 
     public function getTitle(): string
     {
-        return 'Neos Site/Dimension Configuration';
+        return 'Neos site configuration';
     }
 
     public function execute(HealthcheckEnvironment $environment): Health
@@ -45,7 +42,7 @@ class SiteDimensionHealthcheck implements HealthcheckInterface
             $siteConfiguration = $site->getConfiguration();
             if (!self::containsId($siteConfiguration->contentRepositoryId, $registeredContentRepositoryIds)) {
                 return new Health(
-                    'For Site ' . $site->getNodeName() . ', the configured Content Repository ' . $siteConfiguration->contentRepositoryId->value . ' is not registered. Please adjust the contentRepositoryId in Settings.yaml at Neos.Neos.sites / Neos.Neos.sitePresets, and then clear caches via ./flow flow:cache:flush --force.',
+                    'For Site ' . $site->getNodeName() . ', the configured content repository ' . $siteConfiguration->contentRepositoryId->value . ' is not registered. Please adjust the contentRepositoryId in Settings.yaml at Neos.Neos.sites / Neos.Neos.sitePresets, and then clear caches via ./flow flow:cache:flush --force.',
                     Status::ERROR(),
                 );
             }
@@ -54,14 +51,14 @@ class SiteDimensionHealthcheck implements HealthcheckInterface
 
             if (!$contentRepository->getVariationGraph()->getDimensionSpacePoints()->contains($siteConfiguration->defaultDimensionSpacePoint)) {
                 return new Health(
-                    'For Site ' . $site->getNodeName() . ', the defaultDimensionSpacePoint ' . $siteConfiguration->defaultDimensionSpacePoint->toJson() . ' is not part of the configured dimensions of ContentRepository ' . $contentRepository->id->value . ' ' . $contentRepository->getVariationGraph()->getDimensionSpacePoints()->toJson() . '. You need to change Settings.yaml at Neos.Neos.sites.*.contentDimensions.defaultDimensionSpacePoint, and then clear the cache via ./flow flow:cache:flush --force.',
+                    'For Site ' . $site->getNodeName() . ', the defaultDimensionSpacePoint ' . $siteConfiguration->defaultDimensionSpacePoint->toJson() . ' is not part of the configured dimensions of content repository ' . $contentRepository->id->value . ' ' . $contentRepository->getVariationGraph()->getDimensionSpacePoints()->toJson() . '. You need to change Settings.yaml at Neos.Neos.sites.[site-or-*].contentDimensions.defaultDimensionSpacePoint, and then clear the cache via ./flow flow:cache:flush --force.',
                     Status::ERROR(),
                 );
             }
         }
 
         return new Health(
-            'Site and Content Repository Dimensions match - all good!',
+            'Site and content repository dimensions match - all good!',
             Status::OK(),
         );
     }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -10,3 +10,5 @@ Neos:
           className: Neos\Neos\Setup\Infrastructure\Healthcheck\CrHealthcheck
         site:
           className: Neos\Neos\Setup\Infrastructure\Healthcheck\SiteHealthcheck
+        siteDimension:
+          className: Neos\Neos\Setup\Infrastructure\Healthcheck\SiteDimensionHealthcheck


### PR DESCRIPTION
When people start experimenting with Neos 9, this is a common point of poor experience. We strive to give diagnostic tools which point the user to the correct location.

<img width="613" height="121" alt="SCR-20251106-njqc" src="https://github.com/user-attachments/assets/71030d46-bf51-462d-a5ee-d757136e7066" />
<img width="639" height="253" alt="SCR-20251106-njof" src="https://github.com/user-attachments/assets/d9914dd3-d28c-4405-a468-aac0dd17b1cb" />
<img width="628" height="202" alt="SCR-20251106-njgp" src="https://github.com/user-attachments/assets/2ad6db2d-7ad0-42f5-9862-b05835095b5c" />
<img width="624" height="132" alt="SCR-20251106-nizd" src="https://github.com/user-attachments/assets/70c3d280-67c4-45a1-b2bc-bbb95dc9a5ce" />
