### PR TITLE
FEATURE: polish new site configuration check

### DIFF
--- a/Classes/Infrastructure/Healthcheck/SiteConfigurationHealthcheck.php
+++ b/Classes/Infrastructure/Healthcheck/SiteConfigurationHealthcheck.php
@@ -103,7 +103,7 @@ class SiteConfigurationHealthcheck implements HealthcheckInterface
             if (!$contentRepository->getVariationGraph()->getDimensionSpacePoints()->contains($siteConfiguration->defaultDimensionSpacePoint)) {
                 return new Health(
                     sprintf(
-                        'Site configuration "Neos.Neos.sites.%1$s" uses defaultDimensionSpacePoint %2$s which not part of the configured dimensions %3$s of content repository %4s. You need to change Settings.yaml at Neos.Neos.sites.%1$s.contentDimensions.defaultDimensionSpacePoint, and then clear the cache via {{flowCommand}} flow:cache:flush --force.',
+                        'Site configuration "Neos.Neos.sites.%1$s" uses defaultDimensionSpacePoint %2$s which not part of the configured dimensions %3$s of content repository %4s. You need to change Settings.yaml at Neos.Neos.sites.%1$s.contentDimensions.defaultDimensionSpacePoint, and possibly also clear the routing cache via <code>{{flowCommand}} cache:flushone Flow_Mvc_Routing_Route</code>.',
                         $siteNameRaw,
                         $siteConfiguration->defaultDimensionSpacePoint->toJson(),
                         $contentRepository->getVariationGraph()->getDimensionSpacePoints()->toJson(),

--- a/Classes/Infrastructure/Healthcheck/SiteConfigurationHealthcheck.php
+++ b/Classes/Infrastructure/Healthcheck/SiteConfigurationHealthcheck.php
@@ -41,7 +41,7 @@ class SiteConfigurationHealthcheck implements HealthcheckInterface
             $siteConfiguration = $site->getConfiguration();
             if (!self::containsId($siteConfiguration->contentRepositoryId, $registeredContentRepositoryIds)) {
                 return new Health(
-                    'For Site ' . $site->getNodeName() . ', the configured content repository ' . $siteConfiguration->contentRepositoryId->value . ' is not registered. Please adjust the contentRepositoryId in Settings.yaml at Neos.Neos.sites / Neos.Neos.sitePresets, and then clear caches via ./flow flow:cache:flush --force.',
+                    'For Site ' . $site->getNodeName() . ', the configured content repository ' . $siteConfiguration->contentRepositoryId->value . ' is not registered. Please adjust the contentRepositoryId in Settings.yaml at Neos.Neos.sites / Neos.Neos.sitePresets, and then clear caches via {{flowCommand}} flow:cache:flush --force.',
                     Status::ERROR(),
                 );
             }
@@ -50,18 +50,17 @@ class SiteConfigurationHealthcheck implements HealthcheckInterface
 
             if (!$contentRepository->getVariationGraph()->getDimensionSpacePoints()->contains($siteConfiguration->defaultDimensionSpacePoint)) {
                 return new Health(
-                    'For Site ' . $site->getNodeName() . ', the defaultDimensionSpacePoint ' . $siteConfiguration->defaultDimensionSpacePoint->toJson() . ' is not part of the configured dimensions of content repository ' . $contentRepository->id->value . ' ' . $contentRepository->getVariationGraph()->getDimensionSpacePoints()->toJson() . '. You need to change Settings.yaml at Neos.Neos.sites.[site-or-*].contentDimensions.defaultDimensionSpacePoint, and then clear the cache via ./flow flow:cache:flush --force.',
+                    'For Site ' . $site->getNodeName() . ', the defaultDimensionSpacePoint ' . $siteConfiguration->defaultDimensionSpacePoint->toJson() . ' is not part of the configured dimensions of content repository ' . $contentRepository->id->value . ' ' . $contentRepository->getVariationGraph()->getDimensionSpacePoints()->toJson() . '. You need to change Settings.yaml at Neos.Neos.sites.[site-or-*].contentDimensions.defaultDimensionSpacePoint, and then clear the cache via {{flowCommand}} flow:cache:flush --force.',
                     Status::ERROR(),
                 );
             }
         }
 
         return new Health(
-            'Site and content repository dimensions match - all good!',
+            'Neos sites are correctly configured',
             Status::OK(),
         );
     }
-
 
     private static function containsId(ContentRepositoryId $needle, ContentRepositoryIds $ids)
     {

--- a/Classes/Infrastructure/Healthcheck/SiteConfigurationHealthcheck.php
+++ b/Classes/Infrastructure/Healthcheck/SiteConfigurationHealthcheck.php
@@ -12,13 +12,12 @@ use Neos\Setup\Domain\HealthcheckEnvironment;
 use Neos\Setup\Domain\HealthcheckInterface;
 use Neos\Setup\Domain\Status;
 
-class SiteDimensionHealthcheck implements HealthcheckInterface
+class SiteConfigurationHealthcheck implements HealthcheckInterface
 {
     public function __construct(
-        private SiteRepository            $siteRepository,
+        private SiteRepository $siteRepository,
         private ContentRepositoryRegistry $contentRepositoryRegistry,
-    )
-    {
+    ) {
     }
 
     public function getTitle(): string

--- a/Classes/Infrastructure/Healthcheck/SiteConfigurationHealthcheck.php
+++ b/Classes/Infrastructure/Healthcheck/SiteConfigurationHealthcheck.php
@@ -4,18 +4,33 @@ namespace Neos\Neos\Setup\Infrastructure\Healthcheck;
 
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryIds;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeName;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
-use Neos\Neos\Domain\Model\Site;
-use Neos\Neos\Domain\Repository\SiteRepository;
+use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Domain\Model\SiteConfiguration;
 use Neos\Setup\Domain\Health;
 use Neos\Setup\Domain\HealthcheckEnvironment;
 use Neos\Setup\Domain\HealthcheckInterface;
 use Neos\Setup\Domain\Status;
+use Neos\Utility\Arrays;
 
 class SiteConfigurationHealthcheck implements HealthcheckInterface
 {
+    /**
+     * @var array
+     * @phpstan-var array<string,array<string,mixed>>
+     */
+    #[Flow\InjectConfiguration(path: 'sites', package: 'Neos.Neos')]
+    protected $sitesConfiguration = [];
+
+    /**
+     * @var array
+     * @phpstan-var array<string,mixed>
+     */
+    #[Flow\InjectConfiguration(path: 'sitePresets', package: 'Neos.Neos')]
+    protected $sitePresetsConfiguration = [];
+
     public function __construct(
-        private SiteRepository $siteRepository,
         private ContentRepositoryRegistry $contentRepositoryRegistry,
     ) {
     }
@@ -27,21 +42,58 @@ class SiteConfigurationHealthcheck implements HealthcheckInterface
 
     public function execute(HealthcheckEnvironment $environment): Health
     {
-        $sites = $this->siteRepository->findAll();
-        if (count($sites->toArray()) === 0) {
+        if (!isset($this->sitesConfiguration['*'])) {
             return new Health(
-                'No site was added to the system.',
-                Status::NOT_RUN(),
+                'No default site configuration exist at Neos.Neos.sites.*.',
+                Status::ERROR(),
             );
         }
 
         $registeredContentRepositoryIds = $this->contentRepositoryRegistry->getContentRepositoryIds();
-        foreach ($sites as $site) {
-            assert($site instanceof Site);
-            $siteConfiguration = $site->getConfiguration();
+
+        foreach ($this->sitesConfiguration as $siteNameRaw => $siteExplicitConfiguration) {
+            if ($siteNameRaw !== '*') {
+                if (preg_match(NodeName::PATTERN, $siteNameRaw) !== 1) {
+                    $transliterated = NodeName::transliterateFromString($siteNameRaw);
+                    return new Health(
+                        sprintf('The site configuration for Neos.Neos.sites%s will never match a site as the pattern is invalid%s.', $environment->isSafeToLeakTechnicalDetails() ? '.' . $siteNameRaw : '', $environment->isSafeToLeakTechnicalDetails() ? ' did you meant to use ' . $transliterated->value : ''),
+                        Status::ERROR(),
+                    );
+                }
+            }
+
+            // merge site configuration (TODO share code with Site::getConfiguration()? but we need to have this for any site and validate configuration already before it might be possible to build the DTOs)
+            if (isset($siteExplicitConfiguration['preset'])) {
+                if (!is_string($siteExplicitConfiguration['preset'])) {
+                    return new Health(
+                        $environment->isSafeToLeakTechnicalDetails() ? sprintf('Invalid "preset" configuration for "Neos.Neos.sites.%s". Expected string, got: %s', $siteNameRaw, get_debug_type($siteExplicitConfiguration['preset'])) : 'Site preset is not correctly used in Neos.Neos.sites',
+                        Status::ERROR(),
+                    );
+                }
+                if (!isset($this->sitePresetsConfiguration[$siteExplicitConfiguration['preset']]) || !is_array($this->sitePresetsConfiguration[$siteExplicitConfiguration['preset']])) {
+                    return new Health(
+                        $environment->isSafeToLeakTechnicalDetails() ? sprintf('Site configuration "Neos.Neos.sites.%s" refer to a preset "%s", but no corresponding preset is configured', $siteNameRaw, $siteExplicitConfiguration['preset']) : 'Site preset is not correctly configured in Neos.Neos.sitePresets',
+                        Status::ERROR(),
+                    );
+                }
+                $siteMergedConfiguration = Arrays::arrayMergeRecursiveOverrule($this->sitePresetsConfiguration[$siteExplicitConfiguration['preset']], $siteExplicitConfiguration);
+                unset($siteMergedConfiguration['preset']);
+            } else {
+                $siteMergedConfiguration = $siteExplicitConfiguration;
+            }
+
+            try {
+                $siteConfiguration = SiteConfiguration::fromArray($siteMergedConfiguration);
+            } catch (\Throwable $e) {
+                return new Health(
+                    $environment->isSafeToLeakTechnicalDetails() ? sprintf('Site configuration "Neos.Neos.sites.%s" is invalid: %s', $siteNameRaw, $e->getMessage()) : 'Invalid site configuration in Neos.Neos.sites',
+                    Status::ERROR(),
+                );
+            }
+
             if (!self::containsId($siteConfiguration->contentRepositoryId, $registeredContentRepositoryIds)) {
                 return new Health(
-                    'For Site ' . $site->getNodeName() . ', the configured content repository ' . $siteConfiguration->contentRepositoryId->value . ' is not registered. Please adjust the contentRepositoryId in Settings.yaml at Neos.Neos.sites / Neos.Neos.sitePresets, and then clear caches via {{flowCommand}} flow:cache:flush --force.',
+                    $environment->isSafeToLeakTechnicalDetails() ? sprintf('Site configuration "Neos.Neos.sites.%s" uses a content repository "%s" which is not registered. Please adjust the "contentRepositoryId" in Neos.Neos.sites or Neos.Neos.sitePresets.', $siteNameRaw, $siteConfiguration->contentRepositoryId->value) : 'Invalid content repository used in site configuration in Neos.Neos.sites',
                     Status::ERROR(),
                 );
             }
@@ -50,7 +102,13 @@ class SiteConfigurationHealthcheck implements HealthcheckInterface
 
             if (!$contentRepository->getVariationGraph()->getDimensionSpacePoints()->contains($siteConfiguration->defaultDimensionSpacePoint)) {
                 return new Health(
-                    'For Site ' . $site->getNodeName() . ', the defaultDimensionSpacePoint ' . $siteConfiguration->defaultDimensionSpacePoint->toJson() . ' is not part of the configured dimensions of content repository ' . $contentRepository->id->value . ' ' . $contentRepository->getVariationGraph()->getDimensionSpacePoints()->toJson() . '. You need to change Settings.yaml at Neos.Neos.sites.[site-or-*].contentDimensions.defaultDimensionSpacePoint, and then clear the cache via {{flowCommand}} flow:cache:flush --force.',
+                    sprintf(
+                        'Site configuration "Neos.Neos.sites.%1$s" uses defaultDimensionSpacePoint %2$s which not part of the configured dimensions %3$s of content repository %4s. You need to change Settings.yaml at Neos.Neos.sites.%1$s.contentDimensions.defaultDimensionSpacePoint, and then clear the cache via {{flowCommand}} flow:cache:flush --force.',
+                        $siteNameRaw,
+                        $siteConfiguration->defaultDimensionSpacePoint->toJson(),
+                        $contentRepository->getVariationGraph()->getDimensionSpacePoints()->toJson(),
+                        $contentRepository->id->value,
+                    ),
                     Status::ERROR(),
                 );
             }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -8,7 +8,7 @@ Neos:
           className: Neos\Neos\Setup\Infrastructure\Healthcheck\ImageHandlerHealthcheck
         cr:
           className: Neos\Neos\Setup\Infrastructure\Healthcheck\CrHealthcheck
-        site:
-          className: Neos\Neos\Setup\Infrastructure\Healthcheck\SiteHealthcheck
         siteConfiguration:
           className: Neos\Neos\Setup\Infrastructure\Healthcheck\SiteConfigurationHealthcheck
+        site:
+          className: Neos\Neos\Setup\Infrastructure\Healthcheck\SiteHealthcheck

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -10,5 +10,5 @@ Neos:
           className: Neos\Neos\Setup\Infrastructure\Healthcheck\CrHealthcheck
         site:
           className: Neos\Neos\Setup\Infrastructure\Healthcheck\SiteHealthcheck
-        siteDimension:
-          className: Neos\Neos\Setup\Infrastructure\Healthcheck\SiteDimensionHealthcheck
+        siteConfiguration:
+          className: Neos\Neos\Setup\Infrastructure\Healthcheck\SiteConfigurationHealthcheck


### PR DESCRIPTION
Based on https://github.com/neos/neos-setup/pull/22

- Rename to siteConfiguration check in source (label is Neos site configuration)
- Prepend siteConfiguration check _before_ site check is run to ensure mandatory configuration first before importing

### Adjust site configuration check to operate on raw settings and not on added neos sites

this clears up the entanglement from the site configuration vs regular site check and allows to validate the settings before any site is added which might run into that problem. The Neos site step will be automatically skipped in case of an error.
    
we also now validate that the configured sites node names in Neos.Neos.sites are correct as malformed ones would never match and are dead code and might cause confusion or bugs.


*invalid node name*

<img width="806" height="409" alt="image" src="https://github.com/user-attachments/assets/99288866-910f-44f2-ae1d-d6e3d26e33c0" />

*invalid cr name*
<img width="793" height="163" alt="image" src="https://github.com/user-attachments/assets/dcecc913-00e4-47c0-b768-67953d97d0da" />


*not registered cr*

<img width="982" height="258" alt="image" src="https://github.com/user-attachments/assets/0b6b4e86-b636-488f-bb2d-4a66eeb246a9" />

*all running - the active sites step with login is below again :)*

<img width="900" height="293" alt="image" src="https://github.com/user-attachments/assets/dabed650-d6aa-42cd-aa11-3fdc5cb644d8" />

